### PR TITLE
delete manifest tags to avoid merger conflicts

### DIFF
--- a/fragmentation_swipeback/src/main/AndroidManifest.xml
+++ b/fragmentation_swipeback/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
 <manifest package="me.yokeyword.fragmentation_swipeback"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application
-        android:allowBackup="true"
-        android:supportsRtl="true">
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
delete swipeback library's allowBackup and supportsRtl tag