### PR TITLE
correct visible liferecycle

### DIFF
--- a/fragmentation_core/src/main/java/me/yokeyword/fragmentation/helper/internal/VisibleDelegate.java
+++ b/fragmentation_core/src/main/java/me/yokeyword/fragmentation/helper/internal/VisibleDelegate.java
@@ -93,6 +93,11 @@ public class VisibleDelegate {
     }
 
     public void onHiddenChanged(boolean hidden) {
+        if (!hidden && !mFragment.isResumed()) {
+            //if fragment is shown but not resumed, ignore...
+            mInvisibleWhenLeave = false;
+            return;
+        }
         if (hidden) {
             safeDispatchUserVisibleHint(false);
         } else {


### PR DESCRIPTION
fix issue: when fragment launch new activity and finish self, it's pre-fragment will call onSupportVisible and without onSupportInvisble behind.

Signed-off-by: bangelua <bangelua@163.com>