### PR TITLE
Dev

### DIFF
--- a/demo/src/main/java/me/yokeyword/sample/demo_wechat/ui/fragment/first/MsgFragment.java
+++ b/demo/src/main/java/me/yokeyword/sample/demo_wechat/ui/fragment/first/MsgFragment.java
@@ -96,6 +96,7 @@ public class MsgFragment extends BaseBackFragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        mRecy = null;
         _mActivity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
         hideSoftInput();
     }

--- a/fragmentation_core/src/main/java/me/yokeyword/fragmentation/Fragmentation.java
+++ b/fragmentation_core/src/main/java/me/yokeyword/fragmentation/Fragmentation.java
@@ -50,6 +50,8 @@ public class Fragmentation {
         debug = builder.debug;
         if (debug) {
             mode = builder.mode;
+        } else {
+            mode = NONE;
         }
         handler = builder.handler;
     }

--- a/fragmentation_core/src/main/java/me/yokeyword/fragmentation/SupportFragmentDelegate.java
+++ b/fragmentation_core/src/main/java/me/yokeyword/fragmentation/SupportFragmentDelegate.java
@@ -194,7 +194,7 @@ public class SupportFragmentDelegate {
     public void onDestroyView() {
         mSupport.getSupportDelegate().mFragmentClickable = true;
         getVisibleDelegate().onDestroyView();
-        getHandler().removeCallbacks(mNotifyEnterAnimEndRunnable);
+        getHandler().removeCallbacksAndMessages(null);
     }
 
     public void onDestroy() {


### PR DESCRIPTION
1、 修复```onDestoryView```调用```getHander.removeCallbacks(myRunnable)```;后，还有一定几率执行```myRunnable```回调的问题，导致使用 ```BufferkKnife``` 的 ```unbind``` 置空 view 后还执行```onEnterAnimationEnd``` 报 view 的控制针错误