### PR TITLE
修复因类加载加载机制不同，导致 Parcel 数据恢复失败而引起的崩溃

### DIFF
--- a/fragmentation_core/src/main/java/me/yokeyword/fragmentation/SupportFragmentDelegate.java
+++ b/fragmentation_core/src/main/java/me/yokeyword/fragmentation/SupportFragmentDelegate.java
@@ -104,6 +104,7 @@ public class SupportFragmentDelegate {
         if (savedInstanceState == null) {
             getFragmentAnimator();
         } else {
+            savedInstanceState.setClassLoader(getClass().getClassLoader());
             mSaveInstanceState = savedInstanceState;
             mFragmentAnimator = savedInstanceState.getParcelable(TransactionDelegate.FRAGMENTATION_STATE_SAVE_ANIMATOR);
             mIsHidden = savedInstanceState.getBoolean(TransactionDelegate.FRAGMENTATION_STATE_SAVE_IS_HIDDEN);


### PR DESCRIPTION
android.os.BadParcelableException
ClassNotFoundException when unmarshalling: me.yokeyword.fragmentation.anim.FragmentAnimator