### PR TITLE
Fixed DebugHierarchyView of child text fail to see In a few cases

### DIFF
--- a/fragmentation_core/src/main/java/me/yokeyword/fragmentation/debug/DebugHierarchyViewContainer.java
+++ b/fragmentation_core/src/main/java/me/yokeyword/fragmentation/debug/DebugHierarchyViewContainer.java
@@ -173,8 +173,8 @@ public class DebugHierarchyViewContainer extends ScrollView {
 
         ViewGroup.LayoutParams params = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, mItemHeight);
         tvItem.setLayoutParams(params);
+        tvItem.setTextColor(Color.parseColor("#333333"));
         if (hierarchy == 0) {
-            tvItem.setTextColor(Color.parseColor("#333333"));
             tvItem.setTextSize(16);
         }
         tvItem.setGravity(Gravity.CENTER_VERTICAL);


### PR DESCRIPTION
在我这个app中，打开栈视图之后，子级的fragment的名字全部看不到，颜色应该和背景色一样了。

![Screenshot_20190919-164146 1](https://user-images.githubusercontent.com/20589448/65228274-c26c4500-dafc-11e9-9816-8463ea61b072.jpg)
